### PR TITLE
fix: github username and url

### DIFF
--- a/frontend/src/@lekoarts/gatsby-theme-cara/sections/contact.mdx
+++ b/frontend/src/@lekoarts/gatsby-theme-cara/sections/contact.mdx
@@ -1,4 +1,4 @@
 ## 문의사항
 
 * Email: [saengwon.kim@gmail.com](saengwon.kim@gmail.com)
-* Github: [saengwon.kim](https://github.com/saengwon.kim)
+* Github: [saengwon-kim](https://github.com/saengwon-kim)


### PR DESCRIPTION
Fix contact information.

Note that email and GitHub hyperlinks are not clickable, due to a `<div>` overlay.

```html
<div class=" css-gpfi07"
  style="position: absolute; inset: 0px; background-size: auto; background-repeat: no-repeat; will-change: transform; width: 100%; height: 1279px; transform: translate3d(0px, 5499.5px, 0px);">
  <div class=" css-1w8p0sv">
    <h2 class="css-1s0bnj6">문의사항</h2>
    <ul class="css-zezy6m">
      <li class="css-zezy6m">Email: <a href="saengwon.kim@gmail.com" class="css-1diwg7s">saengwon.kim@gmail.com</a></li>
      <li class="css-zezy6m">Github: <a href="https://github.com/saengwon.kim" class="css-1diwg7s">saengwon.kim</a></li>
    </ul>
  </div>
</div>
```